### PR TITLE
feat: Design and create initial database schema

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -1,0 +1,197 @@
+from sqlalchemy import create_engine, Column, Integer, String, Text, Boolean, DateTime, Date, Time, ForeignKey, UniqueConstraint, Index, DECIMAL
+from sqlalchemy.orm import relationship, declarative_base
+from sqlalchemy.sql import func
+import datetime
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "User" # Use quoted name to match PostgreSQL DDL
+
+    user_id = Column(Integer, primary_key=True, autoincrement=True)
+    username = Column(String(50), unique=True, nullable=False)
+    email = Column(String(100), unique=True, nullable=False)
+    password_hash = Column(String(255), nullable=False)
+    first_name = Column(String(50))
+    last_name = Column(String(50))
+    profile_picture_url = Column(String(255))
+    bio = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()) # Relies on DB trigger or SQLAlchemy event for onupdate
+    is_verified = Column(Boolean, default=False)
+    social_provider = Column(String(50))
+    social_id = Column(String(100))
+
+    __table_args__ = (
+        UniqueConstraint('social_provider', 'social_id', name='unique_social_login'),
+        Index('idx_user_email_sa', 'email'), # Index for email, added _sa to avoid clash if DDL index name is same
+    )
+
+    # Relationships
+    trips = relationship("Trip", back_populates="user", cascade="all, delete-orphan")
+    reviews = relationship("Review", back_populates="user", cascade="all, delete-orphan")
+    bookings = relationship("Booking", back_populates="user", cascade="all, delete-orphan")
+    images_uploaded = relationship("Image", foreign_keys="Image.uploaded_by_user_id", back_populates="uploader", cascade="delete, delete-orphan") # cascade adjusted
+    places_created = relationship("Place", foreign_keys="Place.created_by_user_id", back_populates="creator") # Default cascade is save-update, merge
+    favorite_places = relationship("Favorite", back_populates="user", cascade="all, delete-orphan")
+
+class Category(Base):
+    __tablename__ = "Category"
+
+    category_id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(100), unique=True, nullable=False)
+    description = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    # Relationship
+    places = relationship("Place", back_populates="category")
+
+class Place(Base):
+    __tablename__ = "Place"
+
+    place_id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text)
+    address = Column(String(255))
+    latitude = Column(DECIMAL(10, 8))
+    longitude = Column(DECIMAL(11, 8))
+    category_id = Column(Integer, ForeignKey("Category.category_id", ondelete="SET NULL"))
+    contact_email = Column(String(100))
+    contact_phone = Column(String(20))
+    website = Column(String(255))
+    average_rating = Column(DECIMAL(3, 2), default=0.00, nullable=False) # Should be updated by trigger
+    created_by_user_id = Column(Integer, ForeignKey("User.user_id", ondelete="SET NULL"))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    tags = Column(Text)
+
+    __table_args__ = (
+        Index('idx_place_name_sa', 'name'),
+        Index('idx_place_category_id_sa', 'category_id'),
+    )
+
+    # Relationships
+    category = relationship("Category", back_populates="places")
+    creator = relationship("User", foreign_keys=[created_by_user_id], back_populates="places_created")
+    reviews = relationship("Review", back_populates="place", cascade="all, delete-orphan")
+    images = relationship("Image", foreign_keys="Image.place_id", back_populates="place", cascade="all, delete-orphan")
+    bookings = relationship("Booking", back_populates="place", cascade="all, delete-orphan")
+    itinerary_items = relationship("Itinerary", back_populates="place", cascade="all, delete-orphan") # Default cascade might be fine, but being explicit.
+    favorited_by_users = relationship("Favorite", back_populates="place", cascade="all, delete-orphan")
+
+
+class Trip(Base):
+    __tablename__ = "Trip"
+
+    trip_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("User.user_id", ondelete="CASCADE"), nullable=False)
+    name = Column(String(255), nullable=False)
+    description = Column(Text)
+    start_date = Column(Date)
+    end_date = Column(Date)
+    is_public = Column(Boolean, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    # Relationships
+    user = relationship("User", back_populates="trips")
+    itinerary_items = relationship("Itinerary", back_populates="trip", cascade="all, delete-orphan")
+    bookings = relationship("Booking", back_populates="trip") # A trip can have bookings, cascade might need to be SET NULL or handled if Trip is deleted
+
+class Review(Base):
+    __tablename__ = "Review"
+
+    review_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("User.user_id", ondelete="CASCADE"), nullable=False)
+    place_id = Column(Integer, ForeignKey("Place.place_id", ondelete="CASCADE"), nullable=False)
+    rating = Column(Integer, nullable=False)
+    comment = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'place_id', name='uq_user_place_review'),
+        Index('idx_review_place_id_sa', 'place_id'),
+    )
+
+    # Relationships
+    user = relationship("User", back_populates="reviews")
+    place = relationship("Place", back_populates="reviews")
+    images = relationship("Image", foreign_keys="Image.review_id", back_populates="review", cascade="all, delete-orphan")
+
+class Image(Base):
+    __tablename__ = "Image"
+
+    image_id = Column(Integer, primary_key=True, autoincrement=True)
+    image_url = Column(String(255), nullable=False)
+    caption = Column(String(255))
+    uploaded_by_user_id = Column(Integer, ForeignKey("User.user_id", ondelete="SET NULL"))
+    place_id = Column(Integer, ForeignKey("Place.place_id", ondelete="SET NULL"))
+    review_id = Column(Integer, ForeignKey("Review.review_id", ondelete="SET NULL"))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Relationships
+    uploader = relationship("User", foreign_keys=[uploaded_by_user_id], back_populates="images_uploaded")
+    place = relationship("Place", foreign_keys=[place_id], back_populates="images")
+    review = relationship("Review", foreign_keys=[review_id], back_populates="images")
+
+
+class Booking(Base):
+    __tablename__ = "Booking"
+
+    booking_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("User.user_id", ondelete="CASCADE"), nullable=False)
+    place_id = Column(Integer, ForeignKey("Place.place_id", ondelete="CASCADE"), nullable=False)
+    trip_id = Column(Integer, ForeignKey("Trip.trip_id", ondelete="SET NULL"))
+    booking_date = Column(DateTime(timezone=True), nullable=False)
+    number_of_people = Column(Integer, nullable=False, default=1)
+    status = Column(String(20), nullable=False, default='PENDING')
+    notes = Column(Text)
+    total_price = Column(DECIMAL(10, 2))
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    # Relationships
+    user = relationship("User", back_populates="bookings")
+    place = relationship("Place", back_populates="bookings")
+    trip = relationship("Trip", back_populates="bookings")
+
+class Itinerary(Base):
+    __tablename__ = "Itinerary"
+
+    itinerary_item_id = Column(Integer, primary_key=True, autoincrement=True)
+    trip_id = Column(Integer, ForeignKey("Trip.trip_id", ondelete="CASCADE"), nullable=False)
+    place_id = Column(Integer, ForeignKey("Place.place_id", ondelete="CASCADE"), nullable=False)
+    day_number = Column(Integer, nullable=False)
+    start_time = Column(Time)
+    end_time = Column(Time)
+    notes = Column(Text)
+    order_in_day = Column(Integer, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint('trip_id', 'day_number', 'order_in_day', name='uq_trip_day_order'),
+        Index('idx_itinerary_trip_id_sa', 'trip_id'),
+    )
+
+    # Relationships
+    trip = relationship("Trip", back_populates="itinerary_items")
+    place = relationship("Place", back_populates="itinerary_items")
+
+class Favorite(Base):
+    __tablename__ = "Favorite"
+
+    user_id = Column(Integer, ForeignKey("User.user_id", ondelete="CASCADE"), primary_key=True)
+    place_id = Column(Integer, ForeignKey("Place.place_id", ondelete="CASCADE"), primary_key=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Relationships
+    user = relationship("User", back_populates="favorite_places")
+    place = relationship("Place", back_populates="favorited_by_users")
+
+# Note: For SQLAlchemy's onupdate=func.now() to work for existing records' updates,
+# the database trigger for `updated_at` is more reliable, or use SQLAlchemy event listeners.
+# The `server_default` is for insert, `onupdate` for update operations initiated via SQLAlchemy.
+# The DDL triggers ensure `updated_at` is handled at the DB level for any modification.

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,235 @@
+-- SQL DDL for PaiNaiDee Project (PostgreSQL)
+
+-- Drop tables if they exist (optional, for development)
+DROP TABLE IF EXISTS "Favorite" CASCADE;
+DROP TABLE IF EXISTS "Itinerary" CASCADE;
+DROP TABLE IF EXISTS "Booking" CASCADE;
+DROP TABLE IF EXISTS "Image" CASCADE;
+DROP TABLE IF EXISTS "Review" CASCADE;
+DROP TABLE IF EXISTS "Trip" CASCADE;
+DROP TABLE IF EXISTS "Place" CASCADE;
+DROP TABLE IF EXISTS "Category" CASCADE;
+DROP TABLE IF EXISTS "User" CASCADE;
+
+
+-- User Table
+CREATE TABLE "User" (
+    "user_id" SERIAL PRIMARY KEY,
+    "username" VARCHAR(50) UNIQUE NOT NULL,
+    "email" VARCHAR(100) UNIQUE NOT NULL,
+    "password_hash" VARCHAR(255) NOT NULL,
+    "first_name" VARCHAR(50),
+    "last_name" VARCHAR(50),
+    "profile_picture_url" VARCHAR(255),
+    "bio" TEXT,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "is_verified" BOOLEAN DEFAULT FALSE,
+    "social_provider" VARCHAR(50),
+    "social_id" VARCHAR(100),
+    CONSTRAINT "unique_social_login" UNIQUE ("social_provider", "social_id")
+);
+
+-- Category Table
+CREATE TABLE "Category" (
+    "category_id" SERIAL PRIMARY KEY,
+    "name" VARCHAR(100) UNIQUE NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Place Table
+CREATE TABLE "Place" (
+    "place_id" SERIAL PRIMARY KEY,
+    "name" VARCHAR(255) NOT NULL,
+    "description" TEXT,
+    "address" VARCHAR(255),
+    "latitude" DECIMAL(10, 8),
+    "longitude" DECIMAL(11, 8),
+    "category_id" INT,
+    "contact_email" VARCHAR(100),
+    "contact_phone" VARCHAR(20),
+    "website" VARCHAR(255),
+    "average_rating" DECIMAL(3, 2) DEFAULT 0.00,
+    "created_by_user_id" INT,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "tags" TEXT, -- Can be comma-separated or JSON/JSONB for better querying
+    FOREIGN KEY ("category_id") REFERENCES "Category"("category_id") ON DELETE SET NULL,
+    FOREIGN KEY ("created_by_user_id") REFERENCES "User"("user_id") ON DELETE SET NULL
+);
+
+-- Trip Table
+CREATE TABLE "Trip" (
+    "trip_id" SERIAL PRIMARY KEY,
+    "user_id" INT NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "description" TEXT,
+    "start_date" DATE,
+    "end_date" DATE,
+    "is_public" BOOLEAN DEFAULT FALSE,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("user_id") REFERENCES "User"("user_id") ON DELETE CASCADE
+);
+
+-- Review Table
+CREATE TABLE "Review" (
+    "review_id" SERIAL PRIMARY KEY,
+    "user_id" INT NOT NULL,
+    "place_id" INT NOT NULL,
+    "rating" INT NOT NULL CHECK ("rating" >= 1 AND "rating" <= 5),
+    "comment" TEXT,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("user_id") REFERENCES "User"("user_id") ON DELETE CASCADE,
+    FOREIGN KEY ("place_id") REFERENCES "Place"("place_id") ON DELETE CASCADE,
+    UNIQUE ("user_id", "place_id") -- One user can review a place only once
+);
+
+-- Image Table
+CREATE TABLE "Image" (
+    "image_id" SERIAL PRIMARY KEY,
+    "image_url" VARCHAR(255) NOT NULL,
+    "caption" VARCHAR(255),
+    "uploaded_by_user_id" INT,
+    "place_id" INT,
+    "review_id" INT,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("uploaded_by_user_id") REFERENCES "User"("user_id") ON DELETE SET NULL,
+    FOREIGN KEY ("place_id") REFERENCES "Place"("place_id") ON DELETE SET NULL,
+    FOREIGN KEY ("review_id") REFERENCES "Review"("review_id") ON DELETE SET NULL
+);
+
+-- Booking Table
+CREATE TABLE "Booking" (
+    "booking_id" SERIAL PRIMARY KEY,
+    "user_id" INT NOT NULL,
+    "place_id" INT NOT NULL,
+    "trip_id" INT,
+    "booking_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "number_of_people" INT NOT NULL DEFAULT 1,
+    "status" VARCHAR(20) NOT NULL DEFAULT 'PENDING', -- PENDING, CONFIRMED, CANCELLED
+    "notes" TEXT,
+    "total_price" DECIMAL(10, 2),
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("user_id") REFERENCES "User"("user_id") ON DELETE CASCADE,
+    FOREIGN KEY ("place_id") REFERENCES "Place"("place_id") ON DELETE CASCADE,
+    FOREIGN KEY ("trip_id") REFERENCES "Trip"("trip_id") ON DELETE SET NULL
+);
+
+-- Itinerary Table
+CREATE TABLE "Itinerary" (
+    "itinerary_item_id" SERIAL PRIMARY KEY,
+    "trip_id" INT NOT NULL,
+    "place_id" INT NOT NULL,
+    "day_number" INT NOT NULL,
+    "start_time" TIME,
+    "end_time" TIME,
+    "notes" TEXT,
+    "order_in_day" INT NOT NULL,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY ("trip_id") REFERENCES "Trip"("trip_id") ON DELETE CASCADE,
+    FOREIGN KEY ("place_id") REFERENCES "Place"("place_id") ON DELETE CASCADE,
+    CONSTRAINT "unique_event_in_trip_day_order" UNIQUE ("trip_id", "day_number", "order_in_day")
+);
+
+-- Favorite Table (Composite Primary Key)
+CREATE TABLE "Favorite" (
+    "user_id" INT NOT NULL,
+    "place_id" INT NOT NULL,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("user_id", "place_id"),
+    FOREIGN KEY ("user_id") REFERENCES "User"("user_id") ON DELETE CASCADE,
+    FOREIGN KEY ("place_id") REFERENCES "Place"("place_id") ON DELETE CASCADE
+);
+
+-- Triggers for updated_at columns (PostgreSQL specific)
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply the trigger to tables with updated_at
+CREATE TRIGGER set_timestamp_user
+BEFORE UPDATE ON "User"
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+CREATE TRIGGER set_timestamp_category
+BEFORE UPDATE ON "Category"
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+CREATE TRIGGER set_timestamp_place
+BEFORE UPDATE ON "Place"
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+CREATE TRIGGER set_timestamp_trip
+BEFORE UPDATE ON "Trip"
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+CREATE TRIGGER set_timestamp_review
+BEFORE UPDATE ON "Review"
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+CREATE TRIGGER set_timestamp_booking
+BEFORE UPDATE ON "Booking"
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+CREATE TRIGGER set_timestamp_itinerary
+BEFORE UPDATE ON "Itinerary"
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+-- Indexes for performance (examples)
+CREATE INDEX idx_place_name ON "Place" ("name");
+CREATE INDEX idx_place_category_id ON "Place" ("category_id");
+CREATE INDEX idx_place_tags ON "Place" USING GIN (to_tsvector('english', "tags")); -- For FTS on tags
+CREATE INDEX idx_review_place_id ON "Review" ("place_id");
+CREATE INDEX idx_itinerary_trip_id ON "Itinerary" ("trip_id");
+CREATE INDEX idx_user_email ON "User" ("email");
+
+-- Trigger for updating Place.average_rating when Review changes
+CREATE OR REPLACE FUNCTION update_place_average_rating()
+RETURNS TRIGGER AS $$
+DECLARE
+    v_place_id INT;
+BEGIN
+    IF (TG_OP = 'DELETE') THEN
+        v_place_id := OLD.place_id;
+    ELSE
+        v_place_id := NEW.place_id;
+    END IF;
+
+    IF v_place_id IS NOT NULL THEN
+        UPDATE "Place"
+        SET "average_rating" = COALESCE(
+            (SELECT AVG("rating") FROM "Review" WHERE "place_id" = v_place_id),
+            0.00 -- Default to 0 if no reviews
+        )
+        WHERE "place_id" = v_place_id;
+    END IF;
+
+    IF (TG_OP = 'DELETE') THEN
+        RETURN OLD;
+    ELSE
+        RETURN NEW;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER review_changed_update_place_rating
+AFTER INSERT OR UPDATE OF rating OR DELETE ON "Review" -- Trigger on rating update too
+FOR EACH ROW
+EXECUTE FUNCTION update_place_average_rating();


### PR DESCRIPTION
This commit introduces the initial database schema for the "PaiNaiDee" project.

It includes:
- SQL DDL for PostgreSQL, defining tables for Users, Places, Categories, Trips, Itineraries, Reviews, Bookings, Images, and Favorites.
- Constraints, foreign keys, primary keys, and indexes for data integrity and performance.
- Triggers for automatically updating `updated_at` timestamps and `Place.average_rating`.
- Python SQLAlchemy ORM models corresponding to the DDL, including relationships between entities.
- Detailed explanation of the schema design, entity relationships, and examples of API interaction with the database.

This schema is designed to be scalable and support the core features of the application.